### PR TITLE
Bugfix/OpenGraph property

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Here are the available methods:
 | `canonical()`         | `?Url` [🔍](https://github.com/spatie/url)                                                                                  | `<link rel="canonical" href="{this}">`                      |
 | `prev()`              | `?Url` [🔍](https://github.com/spatie/url)                                                                                  | `<link rel="prev" href="{this}">`                           |
 | `next()`              | `?Url` [🔍](https://github.com/spatie/url)                                                                                  | `<link rel="next" href="{this}">`                           |
-| `openGraph()`         | `TagCollection` [🔍](https://github.com/juampi92/test-seo/blob/main/src/Tags/TagCollection.php)                             | `<meta name="og:{key}" content="{value}">`                  |
+| `openGraph()`         | `TagCollection` [🔍](https://github.com/juampi92/test-seo/blob/main/src/Tags/TagCollection.php)                             | `<meta property="og:{key}" content="{value}">`                  |
 | `twitter()`           | `TagCollection` [🔍](https://github.com/juampi92/test-seo/blob/main/src/Tags/TagCollection.php)                             | `<meta name="twitter:{key}" content="{value}">`             |
 | `alternateHrefLang()` | `AlternateHrefLangCollection` [🔍](https://github.com/juampi92/test-seo/blob/main/src/Tags/AlternateHrefLangCollection.php) | `<link name="alternate" hreflang="{hreflang}" href={href}>` |
 | `images()`            | `array<array{src: string, alt: string, title: string}>`                                                                     | All images in the page. `<img src="...">`                   |

--- a/src/SEOData.php
+++ b/src/SEOData.php
@@ -4,6 +4,7 @@ namespace Juampi92\TestSEO;
 
 use Illuminate\Support\Traits\Macroable;
 use Juampi92\TestSEO\Parser\HTMLParser;
+use Juampi92\TestSEO\Support\ArrayPluck;
 use Juampi92\TestSEO\Support\Memo;
 use Juampi92\TestSEO\Tags\AlternateHrefLangCollection;
 use Juampi92\TestSEO\Tags\Robots;
@@ -87,7 +88,12 @@ class SEOData
                 ['property', 'content'],
             );
 
-            return new TagCollection('og:', $tags);
+            $tags = (new ArrayPluck($tags))(key: 'property', value: 'content');
+
+            return new TagCollection(
+                prefix: 'og:',
+                metadata: $tags,
+            );
         });
     }
 
@@ -99,7 +105,12 @@ class SEOData
                 ['name', 'content'],
             );
 
-            return new TagCollection('twitter:', $tags);
+            $tags = (new ArrayPluck($tags))(key: 'name', value: 'content');
+
+            return new TagCollection(
+                prefix: 'twitter:',
+                metadata: $tags,
+            );
         });
     }
 

--- a/src/SEOData.php
+++ b/src/SEOData.php
@@ -83,8 +83,8 @@ class SEOData
     {
         return $this->memo('openGraph', function () {
             $tags = $this->html->grabMultiple(
-                '//html//head//meta[starts-with(@name, "og:")]',
-                ['name', 'content'],
+                '//html//head//meta[starts-with(@property, "og:")]',
+                ['property', 'content'],
             );
 
             return new TagCollection('og:', $tags);

--- a/src/Support/ArrayPluck.php
+++ b/src/Support/ArrayPluck.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Juampi92\TestSEO\Support;
+
+class ArrayPluck
+{
+    /**
+     * @param  array<array<string, string>>  $items
+     */
+    public function __construct(private array $items)
+    {
+    }
+
+    /**
+     * @return array<string, string|array<string>>
+     */
+    public function __invoke(string $key, string $value): array
+    {
+        $array = $this->items;
+        $results = [];
+
+        foreach ($array as $item) {
+            $itemValue = $item[$value];
+            $itemKey = $item[$key];
+
+            if (! isset($results[$itemKey])) {
+                $results[$itemKey] = $itemValue;
+
+                continue;
+            }
+
+            // When there is already a value,
+            // we have to use an array.
+            if (! is_array($results[$itemKey])) {
+                $results[$itemKey] = [$results[$itemKey]];
+            }
+
+            array_push($results[$itemKey], $itemValue);
+        }
+
+        return $results;
+    }
+}

--- a/src/Tags/TagCollection.php
+++ b/src/Tags/TagCollection.php
@@ -4,17 +4,11 @@ namespace Juampi92\TestSEO\Tags;
 
 class TagCollection
 {
-    /** @var array<string, string|array<string>> */
-    private array $metadata;
-
-    /**
-     * @param  array<array{name: string, content: string}>  $metadata
-     */
     public function __construct(
         private string $prefix,
-        array $metadata,
+        /** @var array<string, string|array<string>> */
+        private array $metadata,
     ) {
-        $this->metadata = $this->pluck($metadata);
     }
 
     /**
@@ -31,34 +25,5 @@ class TagCollection
     public function toArray(): array
     {
         return $this->metadata;
-    }
-
-    /**
-     * @param  array<array{name: string, content: string}>  $array
-     * @return array<string, string|array<string>>
-     */
-    private function pluck(array $array): array
-    {
-        $results = [];
-
-        foreach ($array as $item) {
-            ['name' => $name, 'content' => $content] = $item;
-
-            if (! isset($results[$name])) {
-                $results[$name] = $content;
-
-                continue;
-            }
-
-            // When there is already a value,
-            // we have to use an array.
-            if (! is_array($results[$name])) {
-                $results[$name] = [$results[$name]];
-            }
-
-            array_push($results[$name], $content);
-        }
-
-        return $results;
     }
 }

--- a/tests/ArrayPluckTest.php
+++ b/tests/ArrayPluckTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Juampi92\TestSEO\Tests;
+
+use Juampi92\TestSEO\Support\ArrayPluck;
+use PHPUnit\Framework\TestCase;
+
+class ArrayPluckTest extends TestCase
+{
+    /**
+     * @dataProvider pluckDataProvider
+     */
+    public function test_should_pluck_array(array $expected, array $items, string $key, string $value): void
+    {
+        $this->assertEqualsCanonicalizing(
+            $expected,
+            (new ArrayPluck($items))(key: $key, value: $value),
+        );
+    }
+
+    public function pluckDataProvider(): array
+    {
+        return [
+            'It plucks the values' => [
+                'expected' => ['foo' => 'bar', 'foo2' => 'bar2'],
+                'items' => [['name' => 'foo', 'content' => 'bar'], ['name' => 'foo2', 'content' => 'bar2']],
+                'key' => 'name',
+                'value' => 'content',
+            ],
+            'It groups results into an array when the keys are the same' => [
+                'expected' => ['foo' => ['bar', 'bar2'], 'foo2' => 'bar3'],
+                'items' => [
+                    ['property' => 'foo', 'content' => 'bar'],
+                    ['property' => 'foo', 'content' => 'bar2'],
+                    ['property' => 'foo2', 'content' => 'bar3'],
+                ],
+                'key' => 'property',
+                'value' => 'content',
+            ],
+        ];
+    }
+}

--- a/tests/Tags/TagCollectionTest.php
+++ b/tests/Tags/TagCollectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Juampi92\TestSEO\Tests\Tags;
 
+use Juampi92\TestSEO\Support\ArrayPluck;
 use Juampi92\TestSEO\Tags\TagCollection;
 use PHPUnit\Framework\TestCase;
 
@@ -10,9 +11,9 @@ class TagCollectionTest extends TestCase
     public function test_it_should_get_correctly(): void
     {
         // Arrange
-        $metadata = [
-            ['name' => 'og:title', 'content' => 'My title'],
-        ];
+        $metadata = (new ArrayPluck([
+            ['property' => 'og:title', 'content' => 'My title'],
+        ]))(key: 'property', value: 'content');
 
         // Act
         $og = new TagCollection('og:', $metadata);
@@ -26,11 +27,11 @@ class TagCollectionTest extends TestCase
     public function test_it_should_get_array_values(): void
     {
         // Arrange
-        $metadata = [
-            ['name' => 'og:url', 'content' => 'https://image.url/'],
-            ['name' => 'og:image', 'content' => 'https://image.url/here.jpg'],
-            ['name' => 'og:image', 'content' => 'https://image.url/here-2.jpg'],
-        ];
+        $metadata = (new ArrayPluck([
+            ['property' => 'og:url', 'content' => 'https://image.url/'],
+            ['property' => 'og:image', 'content' => 'https://image.url/here.jpg'],
+            ['property' => 'og:image', 'content' => 'https://image.url/here-2.jpg'],
+        ]))(key: 'property', value: 'content');
 
         // Act
         $og = new TagCollection('og:', $metadata);
@@ -46,11 +47,11 @@ class TagCollectionTest extends TestCase
     public function test_it_should_convert_to_array(): void
     {
         // Arrange
-        $metadata = [
+        $metadata = (new ArrayPluck([
             ['name' => 'twitter:url', 'content' => 'https://image.url/'],
             ['name' => 'twitter:image', 'content' => 'https://image.url/here-1.jpg'],
             ['name' => 'twitter:image', 'content' => 'https://image.url/here-2.jpg'],
-        ];
+        ]))(key: 'name', value: 'content');
 
         // Act
         $og = new TagCollection('twitter:', $metadata);

--- a/tests/stubs/test-case-2.html
+++ b/tests/stubs/test-case-2.html
@@ -13,8 +13,8 @@
         <meta name="image" content="https://testpage.com/images/products/44.jpg" />
         <meta name="twitter:card" content="TwitterFooBar #44" />
         <meta name="twitter:image" content="https://testpage.com/images/products/44.jpg" />
-        <meta name="og:site_name" content="OGFooBar" />
-        <meta name="og:image" content="https://testpage.com/images/products/44.jpg" />
+        <meta property="og:site_name" content="OGFooBar" />
+        <meta property="og:image" content="https://testpage.com/images/products/44.jpg" />
 
         <meta name="robots" content="noindex , nofollow" />
 

--- a/tests/stubs/test-case-4.html
+++ b/tests/stubs/test-case-4.html
@@ -5,8 +5,8 @@
         <title>Update product #44 - My Web</title>
         <meta name="author" content="Foo Bar" />
 
-        <meta name="og:image" content="https://testpage.com/images/products/44-front.jpg" />
-        <meta name="og:image" content="https://testpage.com/images/products/44-back.jpg" />
+        <meta property="og:image" content="https://testpage.com/images/products/44-front.jpg" />
+        <meta property="og:image" content="https://testpage.com/images/products/44-back.jpg" />
 
         <link rel="icon" class="js-site-favicon" type="image/svg+xml" href="https://testpage.com/favicons/favicon.svg">
         <meta name="description" content="The product 44 is amazing.">

--- a/tests/stubs/test.html
+++ b/tests/stubs/test.html
@@ -13,8 +13,8 @@
         <meta name="image" content="https://testpage.com/image.jpg" />
         <meta name="twitter:card" content="TwitterFooBar" />
         <meta name="twitter:image" content="https://testpage.com/image.jpg" />
-        <meta name="og:site_name" content="OGFooBar" />
-        <meta name="og:image" content="https://testpage.com/image.jpg" />
+        <meta property="og:site_name" content="OGFooBar" />
+        <meta property="og:image" content="https://testpage.com/image.jpg" />
 
         <meta name="robots" content="index, follow" />
 


### PR DESCRIPTION
As mentioned in #1 , OpenGraph uses "property - content" `<meta property="og:{property}" content...` to define it's properties.
Since twitter uses "name - content" (`<meta name="twitter:{property}" content...`), the solution must accept both.

The fix moves pluck out of the TagCollection and makes it a responsibility of the SEOData to instantiate the TagCollection correctly.