### PR TITLE
Support `->twitter()->title()`

### DIFF
--- a/src/Tags/TagCollection.php
+++ b/src/Tags/TagCollection.php
@@ -22,6 +22,22 @@ class TagCollection
         return $this->metadata[$property] ?? null;
     }
 
+    /**
+     * @return string|array<string>|null
+     */
+    public function __call(string $property, array $arguments)
+    {
+        return $this->get($property);
+    }
+
+    /**
+     * @return string|array<string>|null
+     */
+    public function __get(string $property)
+    {
+        return $this->get($property);
+    }
+
     public function toArray(): array
     {
         return $this->metadata;

--- a/tests/Tags/TagCollectionTest.php
+++ b/tests/Tags/TagCollectionTest.php
@@ -65,4 +65,37 @@ class TagCollectionTest extends TestCase
             ],
         ], $og->toArray());
     }
+
+    public function test_magic_getter_and_call_work(): void
+    {
+        // Arrange
+        $metadata = [
+            'og:title' => 'My Title',
+            'og:image' => [
+                'https://image.url/here.jpg',
+                'https://image.url/here-2.jpg',
+            ],
+        ];
+
+        // Act
+        $og = new TagCollection('og:', $metadata);
+
+        // Assert
+        $this->assertEquals('My Title', $og->title);
+        $this->assertEquals('My Title', $og->title());
+        $this->assertEquals('My Title', $og->get('title'));
+
+        $this->assertEquals([
+            'https://image.url/here.jpg',
+            'https://image.url/here-2.jpg',
+        ], $og->image());
+        $this->assertEquals([
+            'https://image.url/here.jpg',
+            'https://image.url/here-2.jpg',
+        ], $og->image);
+        $this->assertEquals([
+            'https://image.url/here.jpg',
+            'https://image.url/here-2.jpg',
+        ], $og->get('image'));
+    }
 }


### PR DESCRIPTION
This supports calling `->twitter()->title()` or `twitter()->title` to get the title instead of `->twitter()->get('title')`

Addressing #2 