### PR TITLE
Update spatie/url dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": "^8.0.2",
     "illuminate/macroable": "^7.0|^8.0|^9.0",
     "phpunit/phpunit": "^8.3|^9.0",
-    "spatie/url": "^2.1",
+    "spatie/url": "^1.3.4|^2.0",
     "symfony/dom-crawler": "^5.4|^6.1"
   },
   "require-dev": {


### PR DESCRIPTION
Used `1.3.4` since that's the first version that supports PHP 8, the minimum dependency for this package.

https://github.com/spatie/url/blob/main/CHANGELOG.md#134---2020-11-04