### PR TITLE
Update composer.json to be Laravel 11 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": "^8.0.2",
-    "illuminate/macroable": "^7.0|^8.0|^9.0|^10.0",
+    "illuminate/macroable": "^7.0|^8.0|^9.0|^10.0|^11.0",
     "phpunit/phpunit": "^8.3|^9.0|^10.0",
     "spatie/url": "^1.3.4|^2.0",
     "symfony/dom-crawler": "^5.4|^6.1"


### PR DESCRIPTION
Just a minor tweak to the "illuminate/macroable" version requirement. Tested in a Laravel 11 project with Pest without any issues.